### PR TITLE
wget -> requests.get resolved ascii decoding prob of bs4

### DIFF
--- a/get_storyboard_data.py
+++ b/get_storyboard_data.py
@@ -7,6 +7,9 @@ import pickle
 import requests
 import json
 
+from  ftfy import fix_text
+
+
 class Crawler(object):
     def __init__(self):
         self.instructable_ids = []
@@ -41,7 +44,11 @@ class Crawler(object):
                 continue
             soup = BeautifulSoup(codecs.open("index.html", "r",encoding='utf-8', errors='ignore'), "html.parser")
             '''
-            soup = BeautifulSoup(requests.get(url).text, "html.parser")
+            try:
+                soup = BeautifulSoup(requests.get(url).text, "html.parser")
+            except requests.exceptions.RequestException as e:  # for invalid HTTP, Timeout, Toomany redirects
+                print(e)
+                continue
             title = "None"
             try:
                 title = soup.select('h1.header-title')[0].text.strip()
@@ -54,15 +61,20 @@ class Crawler(object):
                     step_title = hit.find(attrs={'class' : 'step-title'}).text
                 except Exception as e:
                     print (e)
-                step['step_title'] = step_title
-                step_body = hit.find(attrs={'class' : 'step-body'}).text
-                step['step_text'] = step_body
+                step['step_title'] = fix_text(step_title)
+                try:
+                    step_body = hit.find(attrs={'class' : 'step-body'}).text
+                except Exception as e:
+                    print(e)
+                    continue
+                step['step_text'] = fix_text(step_body)
                 step['step_images'] = []
                 imgi = 0
                 for el in hit.findAll('img'):
                     if hit.find('div', attrs={'class': 'author-promo'}):
                         continue
                     rename = idd.strip().split("/")[2] + '_' + str(stepi) + '_' + str(imgi)+ ".jpg"
+                    rename = fix_text(rename)
                     try:
                         step['step_images'].append( (el['src'], rename ))
                     except Exception as e:
@@ -80,7 +92,7 @@ class Crawler(object):
             try:
                 os.system('wget -O index.html '+ page)
             except Exception as e:
-                print (e)
+                print(e)
                 continue
             soup = BeautifulSoup(codecs.open("index.html", "r",encoding='utf-8', errors='ignore'), "html.parser")
             for hit in soup.findAll('ul', attrs={'class' : 'sg-card-list'}):
@@ -95,11 +107,22 @@ class Crawler(object):
             recipe = {}
             context = []
             url = "https://snapguide.com"+ idd
+            '''
             try:
                 os.system('wget -O index.html '+ url)
             except:
                 continue
-            soup = BeautifulSoup(open("index.html"), "html.parser")
+            try:
+                soup = BeautifulSoup(codecs.open("index.html", "r",encoding='utf-8', errors='ignore'), "html.parser")
+            except Exception as e:  
+                print(e)
+                continue
+            '''
+            try:
+                soup = BeautifulSoup(requests.get(url).text, "html.parser")
+            except requests.exceptions.RequestException as e:  # for invalid HTTP, Timeout, Toomany redirects
+                print(e)
+                continue
             title = "None"
             try:
                 title = soup.select('title')[0].text.strip()
@@ -112,52 +135,62 @@ class Crawler(object):
                     step_title = hit.find(attrs={'class' : 'step-title'}).text
                 except:
                     step_title = "None"
-                step['step_title'] = step_title
+                step['step_title'] = fix_text(step_title)
                 step_body = "None"
                 try:
                     step_body = hit.find(attrs={'class' : 'caption'}).text
                 except Exception as e:
                     print (e)
-                step['step_text'] = step_body
+                    continue
+                step['step_text'] = fix_text(step_body)
                 step['step_images'] = []
                 imgi = 0
                 for el in hit.findAll('img'):
                     if hit.find('img', attrs={'class': 'step-media'}):
                         if 'auto=webp' not in el['data-src']:
-                            rename = idd.strip().split("/")[2] + '_' + str(stepi) + '_' + str(imgi)+ ".jpg"
-                            step['step_images'].append( ("https:"+el['data-src'], rename ))
+                            rename = (idd.strip().split("/")[2] + '_' + str(stepi) + '_' + str(imgi)+ ".jpg")
+                            rename = fix_text(rename)
+                            step['step_images'].append( ("https:"+el['data-src'], rename) )
                         imgi += 1
                 context.append(step)
             recipe['context'] = context
             recipes.append(recipe)
-            os.system('rm index.html')
+            #os.system('rm index.html')
         return recipes
 
 
 
 def main():
     crawler = Crawler()
-    if os.path.exists("./instructable_ids.pkl"):
-        instructable_ids = pickle.load(open("./instructable_ids.pkl", 'rb'))
-    else:
-        instructable_ids = crawler.get_instructable_ids()
-        pickle.dump(instructable_ids, open("instructable_ids.pkl", 'wb'))
-    if not os.path.exists("./instructable_data.json"):
-        instructables_data = crawler.get_instructables_data(instructable_ids)
-        with open("instructables.json", 'w') as fp:
-            json.dump(instructables_data, fp, indent=4)
-
     if os.path.exists("./snapguide_ids.pkl"):
         snapguide_ids = pickle.load(open("./snapguide_ids.pkl", 'rb'))
+        snapguide_ids = [fixt_text(id) for id in snapguide_ids]
     else:
         snapguide_ids = list(set(crawler.get_snapguide_ids()))
+        snapguide_ids = [fix_text(id) for id in snapguide_ids]
         pickle.dump(snapguide_ids, open("snapguide_ids.pkl", 'wb'))
     if not os.path.exists("./snapguide_data.json"):
         snapguide_data = crawler.get_snapguide_data(snapguide_ids)
         with open("snapguide.json", 'w') as fp:
             json.dump(snapguide_data, fp, indent=4)
 
+    if os.path.exists("./instructable_ids.pkl"):
+        instructable_ids = pickle.load(open("./instructable_ids.pkl", 'rb'))
+        instructable_ids = [fix_text(id) for id in instructable_ids]
+    else:
+        instructable_ids = crawler.get_instructable_ids()
+        instructable_ids = [fix_text(id) for id in instructable_ids]
+
+        pickle.dump(instructable_ids, open("instructable_ids.pkl", 'wb'))
+    if not os.path.exists("./instructable_data.json"):
+        instructables_data = crawler.get_instructables_data(instructable_ids)
+        with open("instructables.json", 'w') as fp:
+            json.dump(instructables_data, fp, indent=4)
+
+
+
+
+
 
 if __name__== "__main__":
     main()
-


### PR DESCRIPTION
1.<code>wget</code> for _snapguide_ data part causes complaints from `bs4` of ascii decoding -> replaced with <code>requests.get(url)</code>
2. potential problems by letter encodings are treated with <code>ftfy.fix_text() </code>. Some might  not be necessary
3. As I needed only corpus part, image part left intact.

### number of recipes crawled (Sep 14, 2019)
````
                            recipe length = 5    /      recipe length > 5    /  recipe  length < 5
snapguide                    41                              771                        133
instructables                4548                          16343                     12264